### PR TITLE
Add password output block

### DIFF
--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -126,3 +126,7 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
     file_name = "cloud-config.yaml"
   }
 }
+
+output "print_temp_password" {
+  value = "Your login password is: ${var.temp_user_password}\nYou will be required to change the password on your first login."
+}

--- a/templates/proxmox.vm.tf
+++ b/templates/proxmox.vm.tf
@@ -42,7 +42,7 @@ provider "proxmox" {
 }
 
 // ********** root.tf or main.tf **********
-module "" {
+module "MODULE_NAME" {
   // Required Variables
   source              = "git::https://github.com/shakir85/terraform_modules.git//proxmox/vm?ref=RELEADE_ID"
   proxmox_node_name   = ""
@@ -65,4 +65,9 @@ module "" {
   # See provider's docs: bpg/proxmox before change the below optional vars
   # disk_interface    = "scsi0"
   # network_interface = "vmbr0"
+}
+
+// Print any output block from the main module
+output "module_outputs" {
+  value = module.MODULE_NAME
 }


### PR DESCRIPTION
Issue: https://github.com/shakir85/Terraform-Modules/issues/18

- Allows printing the default password to the console to avoid ambiguity. 
- Provides a message that password change will be required upon first login.
- Update the template example with the output block to allow printing of main module outputs.