### PR TITLE
Randomize the cloud-init file to prevent unintentional deletion

### DIFF
--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -16,6 +16,12 @@ data "local_file" "ssh_public_key" {
   filename = var.ssh_public_key_path
 }
 
+resource "random_string" "random_cloud_init_id" {
+  length           = 4
+  special          = false
+  upper = false
+}
+
 resource "proxmox_virtual_environment_vm" "vm_resource" {
   name        = var.hostname
   description = var.description
@@ -123,7 +129,7 @@ resource "proxmox_virtual_environment_file" "cloud_config" {
       - echo "done" > /tmp/cloud-config.done
     EOF
 
-    file_name = "cloud-config.yaml"
+    file_name = "cloud-init-config-${var.hostname}-${random_string.random_cloud_init_id.result}.yaml"
   }
 }
 


### PR DESCRIPTION
Resolves https://github.com/shakir85/Terraform-Modules/issues/8

This PR adds the hostname and a random 4-character string to the cloud-init YAML file resource to avoid unintentional deletion when the same Proxmox resource name is used by multiple deployments. When the cloud-config.yml file is overridden or deleted, all VMs using the file will not boot up again if they are stopped.

Since the YAML file is treated as a Terraform resource, it shares the lifecycle of the VM. This tight coupling is beneficial for consistent deployment, regardless of whether the content of the configuration file is redundant.