### PR TITLE
Upgrade bpg provider to v0.70.0

### DIFF
--- a/proxmox/vm/main.tf
+++ b/proxmox/vm/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "bpg/proxmox"
-      version = "0.54.0"
+      version = "0.70.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This PR upgrades the Proxmox provider for the VM (`vm.tf.`) module to v0.70.0.