### PR TITLE
Fix branch-delete workflow

### DIFF
--- a/.github/workflows/delete-branch.yml
+++ b/.github/workflows/delete-branch.yml
@@ -11,6 +11,9 @@ jobs:
     if: github.event.pull_request.merged == true
 
     steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
       - name: Run Git Setup
         uses: ./.github/actions/setup-git
         with:


### PR DESCRIPTION
This PR fixes failed workflow by adding the missing repo-checkout step.